### PR TITLE
Filter publications to just include those from 2020

### DIFF
--- a/covid/question_covid.py
+++ b/covid/question_covid.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
         msg.text("Training new model")
         covid_q = train()
         msg.good("Trained")
-        with open("models/covid_q.pkl", "wb") as f:
+        with open("models/covid_q_2020.pkl", "wb") as f:
             pickle.dump(covid_q, f)
 
 

--- a/covid/question_covid.py
+++ b/covid/question_covid.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
         msg.text("Training new model")
         covid_q = train()
         msg.good("Trained")
-        with open("models/covid_q_2020.pkl", "wb") as f:
+        with open("models/covid_q.pkl", "wb") as f:
             pickle.dump(covid_q, f)
 
 


### PR DESCRIPTION
Fixes https://github.com/wellcometrust/covid19/issues/11

In terms of the logic to `paper_date[0:4] == '2020'` I checked and none of the papers have a publication date where `paper_date[0:4].isnumeric()` is false, so I think we are safe that the publication date is a consistent format. 
I also checked and **all** the publications in the data have a publication year in the metadata (some use the `sha` index and some use `pmcid`).

I ran `python covid/question_covid.py --answers_path 'data/answers/2020-04-15/answers.jsonl'` and uploaded the answers json and the newly trained model (`models/covid_q_2020.pkl`) to S3.